### PR TITLE
Fighter status tracking

### DIFF
--- a/odysseus-config/hardware.ini
+++ b/odysseus-config/hardware.ini
@@ -1,7 +1,6 @@
 [hardware]
-# device = EnttecDMXProDevice
+device = EnttecDMXProDevice
 # port = ttyUSBEnttec
-device = VirtualOutputDevice
 port = ttyUSB0
 
 [channels]

--- a/odysseus-config/hardware.ini
+++ b/odysseus-config/hardware.ini
@@ -1,6 +1,7 @@
 [hardware]
-device = EnttecDMXProDevice
+# device = EnttecDMXProDevice
 # port = ttyUSBEnttec
+device = VirtualOutputDevice
 port = ttyUSB0
 
 [channels]
@@ -22,8 +23,17 @@ sImpulseNone = 15
 sImpulseOn = 16
 sImpulseHigh = 17
 
+sImpulseValue = 18
+
 sEnergyLow = 28
 
+sStarcallerStatus = 30
+sESSODY18Status = 31
+sESSODY23Status = 32
+sESSODY36Status = 33
+
+sFrontShieldValue = 36
+sRearShieldValue = 37
 
 [state]
 condition = HasShip
@@ -229,3 +239,73 @@ condition = Impulse!=0
 target = sImpulseOn
 value = 1.0
 
+[state]
+condition = HasShip
+target = sStarcallerStatus
+effect = variable
+input = LandingPad4Status
+min_input = 0.0
+max_input = 1.0
+min_output = 0.0
+max_output = 1.0
+
+[state]
+condition = HasShip
+target = sESSODY18Status
+effect = variable
+input = LandingPad1Status
+min_input = 0.0
+max_input = 1.0
+min_output = 0.0
+max_output = 1.0
+
+[state]
+condition = HasShip
+target = sESSODY23Status
+effect = variable
+input = LandingPad2Status
+min_input = 0.0
+max_input = 1.0
+min_output = 0.0
+max_output = 1.0
+
+[state]
+condition = HasShip
+target = sESSODY36Status
+effect = variable
+input = LandingPad3Status
+min_input = 0.0
+max_input = 1.0
+min_output = 0.0
+max_output = 1.0
+
+
+[state]
+condition = HasShip
+target = sFrontShieldValue
+effect = variable
+input = FrontShield
+min_input = 0
+max_input = 100
+min_output = 0.0
+max_output = 1.0
+
+[state]
+condition = HasShip
+target = sRearShieldValue
+effect = variable
+input = RearShield
+min_input = 0
+max_input = 100
+min_output = 0.0
+max_output = 1.0
+
+[state]
+condition = HasShip
+target = sImpulseValue
+effect = variable
+input = AbsImpulse
+min_input = 0.0
+max_input = 3.0
+min_output = 0.0
+max_output = 1.0

--- a/scripts/scenario_jump_00.lua
+++ b/scripts/scenario_jump_00.lua
@@ -5,17 +5,25 @@
 require("utils.lua")
 require("utils_odysseus.lua")
 
-
 function init()
-  for n=1,100 do
-			Asteroid():setPosition(random(-100000, 100000), random(-100000, 100000)):setSize(random(100, 500))
-			VisualAsteroid():setPosition(random(-100000, 190000), random(-100000, 100000)):setSize(random(100, 500))
-  end
+  	for n=1,100 do
+		Asteroid():setPosition(random(-100000, 100000), random(-100000, 100000)):setSize(random(100, 500))
+		VisualAsteroid():setPosition(random(-100000, 190000), random(-100000, 100000)):setSize(random(100, 500))
+  	end
 
 	for n=1,10 do
-			Nebula():setPosition(random(-100000, 100000), random(-100000, 100000))
-  end
-  addGMFunction("Change scenario to 01", changeScenarioPrep)
+		Nebula():setPosition(random(-100000, 100000), random(-100000, 100000))
+  	end
+
+	-- Add common GM functions
+	addGMFunction("Sync buttons", sync_buttons)
+	
+	addGMFunction("Enemy north", wavenorth)
+	addGMFunction("Enemy east", waveeast)
+	addGMFunction("Enemy south", wavesouth)
+	addGMFunction("Enemy west", wavewest)
+	
+	addGMFunction("Change scenario to 01", changeScenarioPrep)
 end
 
 function changeScenarioPrep()

--- a/scripts/scenario_jump_01.lua
+++ b/scripts/scenario_jump_01.lua
@@ -7,16 +7,25 @@ require("utils_odysseus.lua")
 
 function init()
 
-  -- Station
-  station = SpaceStation():setFaction("EOC Starfleet"):setTemplate("Medium station"):setCallSign("Solaris 7"):setPosition(20000, 20000)
+  	-- Station
+  	station = SpaceStation():setFaction("EOC Starfleet"):setTemplate("Medium station"):setCallSign("Solaris 7"):setPosition(20000, 20000)
 
-  for n=1,100 do
-    Asteroid():setPosition(random(-100000, 100000), random(-100000, 100000)):setSize(random(100, 500))
+  	for n=1,100 do
+    	Asteroid():setPosition(random(-100000, 100000), random(-100000, 100000)):setSize(random(100, 500))
 		VisualAsteroid():setPosition(random(-100000, 190000), random(-100000, 100000)):setSize(random(100, 500))
-  end
+  	end
 	for n=1,10 do
 		Nebula():setPosition(random(-100000, 100000), random(-100000, 100000))
-  end
+ 	end
+
+	-- Add common GM functions
+	addGMFunction("Sync buttons", sync_buttons)
+
+	addGMFunction("Enemy north", wavenorth)
+	addGMFunction("Enemy east", waveeast)
+	addGMFunction("Enemy south", wavesouth)
+	addGMFunction("Enemy west", wavewest)
+
 	addGMFunction("Change scenario to 02", changeScenarioPrep)
 end
 

--- a/scripts/scenario_jump_02.lua
+++ b/scripts/scenario_jump_02.lua
@@ -7,10 +7,19 @@ require("utils_odysseus.lua")
 
 function init()
 
-  for n=1,100 do
-    Asteroid():setPosition(random(-100000, 100000), random(-100000, 100000)):setSize(random(100, 500))
-    VisualAsteroid():setPosition(random(-100000, 190000), random(-100000, 100000)):setSize(random(100, 500))
-  end
+  	for n=1,100 do
+    	Asteroid():setPosition(random(-100000, 100000), random(-100000, 100000)):setSize(random(100, 500))
+    	VisualAsteroid():setPosition(random(-100000, 190000), random(-100000, 100000)):setSize(random(100, 500))
+  	end
+  
+	-- Add common GM functions
+	addGMFunction("Sync buttons", sync_buttons)
+
+	addGMFunction("Enemy north", wavenorth)
+	addGMFunction("Enemy east", waveeast)
+	addGMFunction("Enemy south", wavesouth)
+	addGMFunction("Enemy west", wavewest)
+	
 	addGMFunction("Change scenario to 03", changeScenarioPrep)
 end
 

--- a/scripts/scenario_jump_03.lua
+++ b/scripts/scenario_jump_03.lua
@@ -7,15 +7,23 @@ require("utils_odysseus.lua")
 
 function init()
 
-  for n=1,100 do
-    Asteroid():setPosition(random(-100000, 100000), random(-100000, 100000)):setSize(random(100, 500))
-    VisualAsteroid():setPosition(random(-100000, 190000), random(-100000, 100000)):setSize(random(100, 500))
-  end
+  	for n=1,100 do
+    	Asteroid():setPosition(random(-100000, 100000), random(-100000, 100000)):setSize(random(100, 500))
+    	VisualAsteroid():setPosition(random(-100000, 190000), random(-100000, 100000)):setSize(random(100, 500))
+  	end
 
   -- Planet
 	planet1 = Planet():setPosition(82000, 40000):setPlanetSurfaceTexture("planets/DE47-HC55.png"):setPlanetRadius(40000)
 
-  addGMFunction("Generate EOC Fleet", function()
+  	-- Add common GM functions
+	addGMFunction("Sync buttons", sync_buttons)
+
+	addGMFunction("Enemy north", wavenorth)
+	addGMFunction("Enemy east", waveeast)
+	addGMFunction("Enemy south", wavesouth)
+	addGMFunction("Enemy west", wavewest)
+
+  	addGMFunction("Generate EOC Fleet", function()
 
 		x, y = odysseus:getPosition()
 

--- a/scripts/scenario_jump_04.lua
+++ b/scripts/scenario_jump_04.lua
@@ -67,12 +67,20 @@ function init()
 
 	starfall = CpuShip():setFaction("Corporate owned"):setTemplate("Cruiser C243"):setPosition(x + random(-10000, 10000), y + random(-10000, 10000)):orderFlyFormation(flagship, -3500, 5500):setScannedByFaction("Corporate owned", true):setScannedByFaction("Faith of the High Science", true):setScannedByFaction("Government owned", true):setScannedByFaction("Unregistered", true):setCallSign("OSS Starfall"):setScannedByFaction("EOC Starfleet", true):setCanBeDestroyed(false)
 
-  for n=1,100 do
-    Asteroid():setPosition(random(-100000, 100000), random(-100000, 100000)):setSize(random(100, 500))
-    VisualAsteroid():setPosition(random(-100000, 190000), random(-100000, 100000)):setSize(random(100, 500))
-  end
+  	for n=1,100 do
+    	Asteroid():setPosition(random(-100000, 100000), random(-100000, 100000)):setSize(random(100, 500))
+    	VisualAsteroid():setPosition(random(-100000, 190000), random(-100000, 100000)):setSize(random(100, 500))
+  	end
 
-  addGMFunction("Destroy ESS vulture", confirm_vulture)
+  	-- Add common GM functions
+	addGMFunction("Sync buttons", sync_buttons)
+
+	addGMFunction("Enemy north", wavenorth)
+	addGMFunction("Enemy east", waveeast)
+	addGMFunction("Enemy south", wavesouth)
+	addGMFunction("Enemy west", wavewest)
+
+  	addGMFunction("Destroy ESS vulture", confirm_vulture)
 	addGMFunction("Change scenario", changeScenarioPrep)
 
 end

--- a/scripts/scenario_jump_05.lua
+++ b/scripts/scenario_jump_05.lua
@@ -78,6 +78,13 @@ function init()
 
 	starfall = CpuShip():setFaction("Corporate owned"):setTemplate("Cruiser C243"):setPosition(x + random(-80000, -60000), y + random(-80000, -60000)):orderFlyFormation(flagship, -3500, 5500):setScannedByFaction("Corporate owned", true):setScannedByFaction("Faith of the High Science", true):setScannedByFaction("Government owned", true):setScannedByFaction("Unregistered", true):setCallSign("OSS Starfall"):setScannedByFaction("EOC Starfleet", true):setCanBeDestroyed(false)
 
+  	-- Add common GM functions
+	addGMFunction("Sync buttons", sync_buttons)
+
+	addGMFunction("Enemy north", wavenorth)
+	addGMFunction("Enemy east", waveeast)
+	addGMFunction("Enemy south", wavesouth)
+	addGMFunction("Enemy west", wavewest)
 
 	addGMFunction("Change scenario to 06", changeScenarioPrep)
 

--- a/scripts/scenario_jump_06.lua
+++ b/scripts/scenario_jump_06.lua
@@ -71,6 +71,13 @@ function init()
 
 	starfall = CpuShip():setFaction("Corporate owned"):setTemplate("Cruiser C243"):setPosition(x + random(-30000, 30000), y + random(-30000, 30000)):orderFlyFormation(flagship, -3500, 5500):setScannedByFaction("Corporate owned", true):setScannedByFaction("Faith of the High Science", true):setScannedByFaction("Government owned", true):setScannedByFaction("Unregistered", true):setCallSign("OSS Starfall"):setScannedByFaction("EOC Starfleet", true):setCanBeDestroyed(false)
 
+	-- Add common GM functions
+	addGMFunction("Sync buttons", sync_buttons)
+	
+	addGMFunction("Enemy north", wavenorth)
+	addGMFunction("Enemy east", waveeast)
+	addGMFunction("Enemy south", wavesouth)
+	addGMFunction("Enemy west", wavewest)
 
 	addGMFunction("Change scenario to 07", changeScenarioPrep)
 

--- a/scripts/scenario_jump_07.lua
+++ b/scripts/scenario_jump_07.lua
@@ -74,6 +74,14 @@ function init()
 
 	starfall = CpuShip():setFaction("Corporate owned"):setTemplate("Cruiser C243"):setPosition(x + random(-80000, -50000), y + random(-80000, -50000)):orderFlyFormation(flagship, -3500, 5500):setScannedByFaction("Corporate owned", true):setScannedByFaction("Faith of the High Science", true):setScannedByFaction("Government owned", true):setScannedByFaction("Unregistered", true):setCallSign("OSS Starfall"):setScannedByFaction("EOC Starfleet", true):setCanBeDestroyed(false)
 
+	-- Add common GM functions
+	addGMFunction("Sync buttons", sync_buttons)
+
+	addGMFunction("Enemy north", wavenorth)
+	addGMFunction("Enemy east", waveeast)
+	addGMFunction("Enemy south", wavesouth)
+	addGMFunction("Enemy west", wavewest)
+
 	addGMFunction("Change scenario to 07", changeScenarioPrep)
 
 end

--- a/scripts/scenario_jump_08.lua
+++ b/scripts/scenario_jump_08.lua
@@ -71,9 +71,16 @@ function init()
 
 	starfall = CpuShip():setFaction("Corporate owned"):setTemplate("Cruiser C243"):setPosition(x + random(-50000, 50000), y + random(-50000, 50000)):orderFlyFormation(aurora, -3500, 5500):setScannedByFaction("Corporate owned", true):setScannedByFaction("Faith of the High Science", true):setScannedByFaction("Government owned", true):setScannedByFaction("Unregistered", true):setCallSign("OSS Starfall"):setScannedByFaction("EOC Starfleet", true):setCanBeDestroyed(false)
 
+	-- Add common GM functions
+	addGMFunction("Sync buttons", sync_buttons)
+
+	addGMFunction("Enemy north", wavenorth)
+	addGMFunction("Enemy east", waveeast)
+	addGMFunction("Enemy south", wavesouth)
+	addGMFunction("Enemy west", wavewest)
 
 	addGMFunction("EOC orders", eoc_orders)
-  addGMFunction("Destroy ESS polaris", confirm_polaris)
+  	addGMFunction("Destroy ESS polaris", confirm_polaris)
 	addGMFunction("Change scenario to 09", changeScenarioPrep)
 
 end

--- a/scripts/scenario_jump_09.lua
+++ b/scripts/scenario_jump_09.lua
@@ -61,7 +61,13 @@ function init()
 
 	starfall = CpuShip():setFaction("Corporate owned"):setTemplate("Cruiser C243"):setPosition(x + random(-80000, -50000), y + random(-80000, -50000)):orderFlyFormation(flagship, -3500, 5500):setScannedByFaction("Corporate owned", true):setScannedByFaction("Faith of the High Science", true):setScannedByFaction("Government owned", true):setScannedByFaction("Unregistered", true):setCallSign("OSS Starfall"):setScannedByFaction("EOC Starfleet", true):setCanBeDestroyed(false)
 
+	-- Add common GM functions
+	addGMFunction("Sync buttons", sync_buttons)
 
+	addGMFunction("Enemy north", wavenorth)
+	addGMFunction("Enemy east", waveeast)
+	addGMFunction("Enemy south", wavesouth)
+	addGMFunction("Enemy west", wavewest)
 
 	addGMFunction("Change scenario to 10", changeScenarioPrep)
 end

--- a/scripts/scenario_jump_10.lua
+++ b/scripts/scenario_jump_10.lua
@@ -62,7 +62,13 @@ function init()
 
 	starfall = CpuShip():setFaction("Corporate owned"):setTemplate("Cruiser C243"):setPosition(x + random(-10000, 10000), y + random(-10000, 10000)):orderFlyFormation(flagship, -3500, 5500):setScannedByFaction("Corporate owned", true):setScannedByFaction("Faith of the High Science", true):setScannedByFaction("Government owned", true):setScannedByFaction("Unregistered", true):setCallSign("OSS Starfall"):setScannedByFaction("EOC Starfleet", true):setCanBeDestroyed(false)
 
+	-- Add common GM functions
+	addGMFunction("Sync buttons", sync_buttons)
 
+	addGMFunction("Enemy north", wavenorth)
+	addGMFunction("Enemy east", waveeast)
+	addGMFunction("Enemy south", wavesouth)
+	addGMFunction("Enemy west", wavewest)
 
 	addGMFunction("Change scenario to 11", changeScenarioPrep)
 

--- a/scripts/scenario_jump_11.lua
+++ b/scripts/scenario_jump_11.lua
@@ -63,6 +63,13 @@ function init()
 
 	immortal = CpuShip():setFaction("Corporate owned"):setTemplate("Cruiser C243"):setPosition(x + random(-80000, -50000), y + random(-80000, -50000)):orderFlyFormation(flagship, -5500, 3500):setScannedByFaction("Corporate owned", true):setScannedByFaction("Faith of the High Science", true):setScannedByFaction("Government owned", true):setScannedByFaction("Unregistered", true):setCallSign("OSS Immortal"):setScannedByFaction("EOC Starfleet", true):setCanBeDestroyed(false)
 
+	-- Add common GM functions
+	addGMFunction("Sync buttons", sync_buttons)
+
+	addGMFunction("Enemy north", wavenorth)
+	addGMFunction("Enemy east", waveeast)
+	addGMFunction("Enemy south", wavesouth)
+	addGMFunction("Enemy west", wavewest)
 
 	addGMFunction("Change scenario to 12", changeScenarioPrep)
 end

--- a/scripts/scenario_jump_12.lua
+++ b/scripts/scenario_jump_12.lua
@@ -11,6 +11,14 @@ function init()
 		Asteroid():setPosition(random(-75000, 75000), random(-75000, 75000))
 	end
 
+	-- Add common GM functions
+	addGMFunction("Sync buttons", sync_buttons)
+
+	addGMFunction("Enemy north", wavenorth)
+	addGMFunction("Enemy east", waveeast)
+	addGMFunction("Enemy south", wavesouth)
+	addGMFunction("Enemy west", wavewest)
+
 	addGMFunction("Change scenario to 13", changeScenarioPrep)
 
 end

--- a/scripts/scenario_jump_13.lua
+++ b/scripts/scenario_jump_13.lua
@@ -127,6 +127,13 @@ function init()
 
 	starfall = CpuShip():setFaction("Corporate owned"):setTemplate("Cruiser C243"):setPosition(x + random(-20000, 20000), y + random(-50000, -35000)):orderFlyFormation(flagship, -3500, 5500):setScannedByFaction("Corporate owned", true):setScannedByFaction("Faith of the High Science", true):setScannedByFaction("Government owned", true):setScannedByFaction("Unregistered", true):setCallSign("OSS Starfall"):setScannedByFaction("EOC Starfleet", true):setCanBeDestroyed(false)
 
+	-- Add common GM functions
+	addGMFunction("Sync buttons", sync_buttons)
+
+	addGMFunction("Enemy north", wavenorth)
+	addGMFunction("Enemy east", waveeast)
+	addGMFunction("Enemy south", wavesouth)
+	addGMFunction("Enemy west", wavewest)
 
 	addGMFunction("Change scenario to 14", changeScenarioPrep)
 

--- a/scripts/scenario_jump_14.lua
+++ b/scripts/scenario_jump_14.lua
@@ -66,6 +66,13 @@ function init()
 
 	starfall = CpuShip():setFaction("Corporate owned"):setTemplate("Cruiser C243"):setPosition(x + random(-10000, 15000), y + random(-10000, 10000)):orderFlyFormation(flagship, -3500, 5500):setScannedByFaction("Corporate owned", true):setScannedByFaction("Faith of the High Science", true):setScannedByFaction("Government owned", true):setScannedByFaction("Unregistered", true):setCallSign("OSS Starfall"):setScannedByFaction("EOC Starfleet", true):setCanBeDestroyed(false)
 
+	-- Add common GM functions
+	addGMFunction("Sync buttons", sync_buttons)
+
+	addGMFunction("Enemy north", wavenorth)
+	addGMFunction("Enemy east", waveeast)
+	addGMFunction("Enemy south", wavesouth)
+	addGMFunction("Enemy west", wavewest)
 
 	addGMFunction("Change scenario to 15", changeScenarioPrep)
 	addGMFunction("Destroy ESS Valkyrie", confirm_valkyrie)

--- a/scripts/scenario_jump_15.lua
+++ b/scripts/scenario_jump_15.lua
@@ -72,6 +72,13 @@ function init()
 
 	starfall = CpuShip():setFaction("Corporate owned"):setTemplate("Cruiser C243"):setPosition(x + random(-80000, -50000), y + random(-80000, -50000)):orderFlyFormation(flagship, -3500, 5500):setScannedByFaction("Corporate owned", true):setScannedByFaction("Faith of the High Science", true):setScannedByFaction("Government owned", true):setScannedByFaction("Unregistered", true):setCallSign("OSS Starfall"):setScannedByFaction("EOC Starfleet", true):setCanBeDestroyed(false)
 
+	-- Add common GM functions
+	addGMFunction("Sync buttons", sync_buttons)
+
+	addGMFunction("Enemy north", wavenorth)
+	addGMFunction("Enemy east", waveeast)
+	addGMFunction("Enemy south", wavesouth)
+	addGMFunction("Enemy west", wavewest)
 
 	addGMFunction("Change scenario to 16", changeScenarioPrep)
 end

--- a/scripts/scenario_jump_16.lua
+++ b/scripts/scenario_jump_16.lua
@@ -72,7 +72,15 @@ function init()
 
 	starfall = CpuShip():setFaction("Corporate owned"):setTemplate("Cruiser C243"):setPosition(x + random(-30000, 10000), y + random(-20000, 20000)):orderFlyFormation(flagship, -3500, 5500):setScannedByFaction("Corporate owned", true):setScannedByFaction("Faith of the High Science", true):setScannedByFaction("Government owned", true):setScannedByFaction("Unregistered", true):setCallSign("OSS Starfall"):setScannedByFaction("EOC Starfleet", true):setCanBeDestroyed(false)
 
-  addGMFunction("Enemy wave one + Nest", wave_one)
+	-- Add common GM functions
+	addGMFunction("Sync buttons", sync_buttons)
+
+	addGMFunction("Enemy north", wavenorth)
+	addGMFunction("Enemy east", waveeast)
+	addGMFunction("Enemy south", wavesouth)
+	addGMFunction("Enemy west", wavewest)
+
+  	addGMFunction("Enemy wave one + Nest", wave_one)
 
 
 end

--- a/scripts/utils_odysseus.lua
+++ b/scripts/utils_odysseus.lua
@@ -62,63 +62,87 @@ end
 -- Ship Enabler
 
 function allow_essody18()
-	odysseus:addCustomButton("Relay", "Launch ESSODY18", "Launch ESSODY18", launch_essody18)
+	odysseus:addCustomButton("Relay", "launch_pad_1", "Launch ESSODY18", launch_essody18)
+  	odysseus:setLandingPadDocked(1)
 	removeGMFunction("Allow ESSODY18")
 end
 function allow_essody23()
-	odysseus:addCustomButton("Relay", "Launch ESSODY23", "Launch ESSODY23", launch_essody23)
+	odysseus:addCustomButton("Relay", "launch_pad_2", "Launch ESSODY23", launch_essody23)
+  	odysseus:setLandingPadDocked(2)
 	removeGMFunction("Allow ESSODY23")
 end
 function allow_essody36()
-	odysseus:addCustomButton("Relay", "Launch ESSODY36", "Launch ESSODY36", launch_essody36)
+	odysseus:addCustomButton("Relay", "launch_pad_3", "Launch ESSODY36", launch_essody36)
+  	odysseus:setLandingPadDocked(3)
 	removeGMFunction("Allow ESSODY36")
 end
 function allow_starcaller()
-	odysseus:addCustomButton("Relay", "Launch STARCALLER", "Launch STARCALLER", launch_starcaller)
+	odysseus:addCustomButton("Relay", "launch_pad_4", "Launch STARCALLER", launch_starcaller)
+  	odysseus:setLandingPadDocked(4)
 	removeGMFunction("Allow STARCALLER")
 end
 
 -- Ship Launcher (simplified and removed unnecessary confirmation)
 function launch_essody18()
-	odysseus:removeCustom("Launch ESSODY18")
+	odysseus:removeCustom("launch_pad_1")
 	spawn_essody18()
 end
 function launch_essody23()
-	odysseus:removeCustom("Launch ESSODY23")
+	odysseus:removeCustom("launch_pad_2")
 	spawn_essody23()
 end
 function launch_essody36()
-	odysseus:removeCustom("Launch ESSODY36")
+	odysseus:removeCustom("launch_pad_3")
 	spawn_essody36()
 end
 function launch_starcaller()
-	odysseus:removeCustom("Launch STARCALLER")
+	odysseus:removeCustom("launch_pad_4")
 	spawn_starcaller()
 end
 
 -- Ship spawner
 function spawn_essody18()
 	x, y = odysseus:getPosition()
-	essody18 = PlayerSpaceship():setFaction("EOC Starfleet"):setTemplate("Fighter F967"):setPosition(x + 200, y + 200):setCallSign("ESSODY18"):setAutoCoolant(true)
-	essody18:addCustomButton("Helms", "Dock to Odysseys", "Dock to Odysseys", dock_essody18)
+	essody18 = PlayerSpaceship():setFaction("EOC Starfleet"):setTemplate("Fighter F967"):setPosition(x + 200, y + 200):setCallSign("ESSODY18"):setAutoCoolant(true):onDestruction(
+	function(this, instigator) 
+		odysseus:setLandingPadDestroyed(2)
+		addGMFunction("Allow ESSODY23", allow_essody23)
+	end)
+	essody18:addCustomButton("Helms", "dock_to_odysseus", "Dock to Odysseys", dock_essody18)
+  	odysseus:setLandingPadLaunched(1)
 	essody18_launched = 1
 end
 function spawn_essody23()
 	x, y = odysseus:getPosition()
-	essody23 = PlayerSpaceship():setFaction("EOC Starfleet"):setTemplate("Fighter F967"):setPosition(x + 250, y + 250):setCallSign("ESSODY23"):setAutoCoolant(true)
-	essody23:addCustomButton("Helms", "Dock to Odysseys", "Dock to Odysseys", dock_essody23)
+	essody23 = PlayerSpaceship():setFaction("EOC Starfleet"):setTemplate("Fighter F967"):setPosition(x + 250, y + 250):setCallSign("ESSODY23"):setAutoCoolant(true):onDestruction(
+    function(this, instigator) 
+      	odysseus:setLandingPadDestroyed(2)
+      	addGMFunction("Allow ESSODY23", allow_essody23)
+    end)
+	essody23:addCustomButton("Helms", "dock_to_odysseus", "Dock to Odysseys", dock_essody23)
+  	odysseus:setLandingPadLaunched(2)
 	essody23_launched = 1
 end
 function spawn_essody36()
 	x, y = odysseus:getPosition()
-	essody36 = PlayerSpaceship():setFaction("EOC Starfleet"):setTemplate("Fighter F967"):setPosition(x + 300, y + 300):setCallSign("ESSODY36"):setAutoCoolant(true)
-	essody36:addCustomButton("Helms", "Dock to Odysseys", "Dock to Odysseys", dock_essody36)
+	essody36 = PlayerSpaceship():setFaction("EOC Starfleet"):setTemplate("Fighter F967"):setPosition(x + 300, y + 300):setCallSign("ESSODY36"):setAutoCoolant(true):onDestruction(
+    function(this, instigator) 
+      	odysseus:setLandingPadDestroyed(3)
+      	addGMFunction("Allow ESSODY36", allow_essody36)
+    end)
+	essody36:addCustomButton("Helms", "dock_to_odysseus", "Dock to Odysseys", dock_essody36)
+  	odysseus:setLandingPadLaunched(3)
 	essody36_launched = 1
 end
 function spawn_starcaller()
 	x, y = odysseus:getPosition()
-	starcaller = PlayerSpaceship():setFaction("EOC Starfleet"):setTemplate("Scoutship S392"):setPosition(x - 400, y + 400):setCallSign("ESS Starcaller"):setAutoCoolant(true)
-	starcaller:addCustomButton("Helms", "Dock to Odysseys", "Dock to Odysseys", dock_starcaller)
+	starcaller = PlayerSpaceship():setFaction("EOC Starfleet"):setTemplate("Scoutship S392"):setPosition(x - 400, y + 400):setCallSign("ESS Starcaller"):setAutoCoolant(true):onDestruction(
+    function(this, instigator) 
+      	odysseus:setLandingPadDestroyed(4)
+      	addGMFunction("Allow STARCALLER", allow_starcaller)
+    end)
+	starcaller:addCustomButton("Helms", "dock_to_odysseus", "Dock to Odysseys", dock_starcaller)
+  	odysseus:setLandingPadLaunched(4)
 	starcaller_launched = 1
 end
 
@@ -132,7 +156,8 @@ function dock_essody18()
 		if callSign == "ESS Odysseus" then
 			essody18:destroy()
 			essody18_launched = 0
-			odysseus:addCustomButton("Relay", "Launch ESSODY18", "Launch ESSODY18", launch_essody18)
+      odysseus:setLandingPadDocked(1)
+			odysseus:addCustomButton("Relay", "launch_pad_1", "Launch ESSODY18", launch_essody18)
 		else
 			essody18:addCustomMessage("Helms", "Distance too far. Docking cancelled.", "Distance too far. Docking cancelled.")
 		end
@@ -145,7 +170,8 @@ function dock_essody23()
 		if callSign == "ESS Odysseus" then
 			essody23:destroy()
 			essody23_launched = 0
-			odysseus:addCustomButton("Relay", "Launch ESSODY23", "Launch ESSODY23", launch_essody23)
+      odysseus:setLandingPadDocked(2)
+			odysseus:addCustomButton("Relay", "launch_pad_2", "Launch ESSODY23", launch_essody23)
 		else
 			essody23:addCustomMessage("Helms", "Distance too far. Docking cancelled.", "Distance too far. Docking cancelled.")
 		end
@@ -158,7 +184,8 @@ function dock_essody36()
 		if callSign == "ESS Odysseus" then
 			essody36:destroy()
 			essody36_launched = 0
-			odysseus:addCustomButton("Relay", "Launch ESSODY36", "Launch ESSODY36", launch_essody36)
+      odysseus:setLandingPadDocked(3)
+			odysseus:addCustomButton("Relay", "launch_pad_3", "Launch ESSODY36", launch_essody36)
 		else
 			essody36:addCustomMessage("Helms", "Distance too far. Docking cancelled.", "Distance too far. Docking cancelled.")
 		end
@@ -171,7 +198,8 @@ function dock_starcaller()
 		if callSign == "ESS Odysseus" then
 			starcaller:destroy()
 			starcaller_launched = 0
-			odysseus:addCustomButton("Relay", "Launch STARCALLER", "Launch STARCALLER", launch_starcaller)
+      odysseus:setLandingPadDocked(4)
+			odysseus:addCustomButton("Relay", "launch_pad_4", "Launch STARCALLER", launch_starcaller)
 		else
 			starcaller:addCustomMessage("Helms", "Distance too far. Docking cancelled.", "Distance too far. Docking cancelled.")
 		end

--- a/scripts/utils_odysseus.lua
+++ b/scripts/utils_odysseus.lua
@@ -2,15 +2,15 @@
 -- Modified and simplified the functions after the Odysseus larp by Mikko B
 -- FOR SOME REASON THE FIRST SCENE NEEDS TO BE LOADED TWICE FOR THE SCRIPTS TO WORK PROPERLY.
 
--- Add common GM functions
-addGMFunction("Enemy north", wavenorth)
-addGMFunction("Enemy east", waveeast)
-addGMFunction("Enemy south", wavesouth)
-addGMFunction("Enemy west", wavewest)
-addGMFunction("Allow ESSODY18", allow_essody18)
-addGMFunction("Allow ESSODY23", allow_essody23)
-addGMFunction("Allow ESSODY36", allow_essody36)
-addGMFunction("Allow STARCALLER", allow_starcaller)
+-- Add common GM functions (these need to be added in the scenario scripts, so commented out here -Ville)
+-- addGMFunction("Enemy north", wavenorth)
+-- addGMFunction("Enemy east", waveeast)
+-- addGMFunction("Enemy south", wavesouth)
+-- addGMFunction("Enemy west", wavewest)
+-- addGMFunction("Allow ESSODY18", allow_essody18)
+-- addGMFunction("Allow ESSODY23", allow_essody23)
+-- addGMFunction("Allow ESSODY36", allow_essody36)
+-- addGMFunction("Allow STARCALLER", allow_starcaller)
 
 -- spawn the ESS Odysseus
 odysseus = PlayerSpaceship():setFaction("EOC Starfleet"):setTemplate("Corvette C743"):setCallSign("ESS Odysseus"):setPosition(0, 0):setCanBeDestroyed(false)
@@ -105,8 +105,8 @@ function spawn_essody18()
 	x, y = odysseus:getPosition()
 	essody18 = PlayerSpaceship():setFaction("EOC Starfleet"):setTemplate("Fighter F967"):setPosition(x + 200, y + 200):setCallSign("ESSODY18"):setAutoCoolant(true):onDestruction(
 	function(this, instigator) 
-		odysseus:setLandingPadDestroyed(2)
-		addGMFunction("Allow ESSODY23", allow_essody23)
+		odysseus:setLandingPadDestroyed(1)
+		addGMFunction("Allow ESSODY18", allow_essody18)
 	end)
 	essody18:addCustomButton("Helms", "dock_to_odysseus", "Dock to Odysseys", dock_essody18)
   	odysseus:setLandingPadLaunched(1)
@@ -154,54 +154,92 @@ function dock_essody18()
 	for _, obj in ipairs(getObjectsInRadius(x, y, dockingdist)) do
 		callSign = obj:getCallSign()
 		if callSign == "ESS Odysseus" then
-			essody18:destroy()
 			essody18_launched = 0
-      odysseus:setLandingPadDocked(1)
+      		odysseus:setLandingPadDocked(1)
 			odysseus:addCustomButton("Relay", "launch_pad_1", "Launch ESSODY18", launch_essody18)
-		else
-			essody18:addCustomMessage("Helms", "Distance too far. Docking cancelled.", "Distance too far. Docking cancelled.")
+			essody18:destroy()
+			return
 		end
 	end
+	essody18:addCustomMessage("Helms", "Distance too far. Docking cancelled.", "Distance too far. Docking cancelled.")
 end
 function dock_essody23()
 	x, y = essody23:getPosition()
 	for _, obj in ipairs(getObjectsInRadius(x, y, dockingdist)) do
 		callSign = obj:getCallSign()
 		if callSign == "ESS Odysseus" then
-			essody23:destroy()
 			essody23_launched = 0
-      odysseus:setLandingPadDocked(2)
+      		odysseus:setLandingPadDocked(2)
 			odysseus:addCustomButton("Relay", "launch_pad_2", "Launch ESSODY23", launch_essody23)
-		else
-			essody23:addCustomMessage("Helms", "Distance too far. Docking cancelled.", "Distance too far. Docking cancelled.")
+			essody23:destroy()
+			return
 		end
 	end
+	essody23:addCustomMessage("Helms", "Distance too far. Docking cancelled.", "Distance too far. Docking cancelled.")
 end
 function dock_essody36()
 	x, y = essody36:getPosition()
 	for _, obj in ipairs(getObjectsInRadius(x, y, dockingdist)) do
 		callSign = obj:getCallSign()
 		if callSign == "ESS Odysseus" then
-			essody36:destroy()
 			essody36_launched = 0
-      odysseus:setLandingPadDocked(3)
+      		odysseus:setLandingPadDocked(3)
 			odysseus:addCustomButton("Relay", "launch_pad_3", "Launch ESSODY36", launch_essody36)
-		else
-			essody36:addCustomMessage("Helms", "Distance too far. Docking cancelled.", "Distance too far. Docking cancelled.")
+			essody36:destroy()
+			return
 		end
 	end
+	essody36:addCustomMessage("Helms", "Distance too far. Docking cancelled.", "Distance too far. Docking cancelled.")
 end
 function dock_starcaller()
 	x, y = starcaller:getPosition()
 	for _, obj in ipairs(getObjectsInRadius(x, y, dockingdist)) do
 		callSign = obj:getCallSign()
 		if callSign == "ESS Odysseus" then
-			starcaller:destroy()
 			starcaller_launched = 0
-      odysseus:setLandingPadDocked(4)
+      		odysseus:setLandingPadDocked(4)
 			odysseus:addCustomButton("Relay", "launch_pad_4", "Launch STARCALLER", launch_starcaller)
-		else
-			starcaller:addCustomMessage("Helms", "Distance too far. Docking cancelled.", "Distance too far. Docking cancelled.")
+			starcaller:destroy()
+			return
 		end
+	end
+	starcaller:addCustomMessage("Helms", "Distance too far. Docking cancelled.", "Distance too far. Docking cancelled.")
+end
+
+-- Button synchronizer
+function sync_buttons()
+	removeGMFunction("Allow ESSODY18")
+	removeGMFunction("Allow ESSODY23")
+	removeGMFunction("Allow ESSODY36")
+	removeGMFunction("Allow STARCALLER")
+	odysseus:removeCustom("launch_pad_1")
+	odysseus:removeCustom("launch_pad_2")
+	odysseus:removeCustom("launch_pad_3")
+	odysseus:removeCustom("launch_pad_4")
+	
+	if odysseus:isLandingPadDestroyed(1) then
+		addGMFunction("Allow ESSODY18", allow_essody18)
+	end
+	if odysseus:isLandingPadDestroyed(2) then
+		addGMFunction("Allow ESSODY23", allow_essody23)
+	end
+	if odysseus:isLandingPadDestroyed(3) then
+		addGMFunction("Allow ESSODY36", allow_essody36)
+	end
+	if odysseus:isLandingPadDestroyed(4) then
+		addGMFunction("Allow STARCALLER", allow_starcaller)
+	end
+
+	if odysseus:isLandingPadDocked(1) then
+		odysseus:addCustomButton("Relay", "launch_pad_1", "Launch ESSODY18", launch_essody18)
+	end
+	if odysseus:isLandingPadDocked(2) then
+		odysseus:addCustomButton("Relay", "launch_pad_2", "Launch ESSODY23", launch_essody23)
+	end
+	if odysseus:isLandingPadDocked(3) then
+		odysseus:addCustomButton("Relay", "launch_pad_3", "Launch ESSODY36", launch_essody36)
+	end
+	if odysseus:isLandingPadDocked(4) then
+		odysseus:addCustomButton("Relay", "launch_pad_4", "Launch STARCALLER", launch_starcaller)
 	end
 end

--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -272,7 +272,13 @@ Keys::Keys() :
     spectator_show_callsigns("SPECTATOR_SHOW_CALLSIGNS", "C"),
 
     debug_show_fps("DEBUG_SHOW_FPS", "F10"),
-    debug_show_timing("DEBUG_SHOW_TIMING", "F11")
+    debug_show_timing("DEBUG_SHOW_TIMING", "F11"),
+
+    custom_button_launch_pad_1("CUSTOM_BUTTON_LAUNCH_PAD_1"),
+    custom_button_launch_pad_2("CUSTOM_BUTTON_LAUNCH_PAD_2"),
+    custom_button_launch_pad_3("CUSTOM_BUTTON_LAUNCH_PAD_3"),
+    custom_button_launch_pad_4("CUSTOM_BUTTON_LAUNCH_PAD_4"),
+    custom_button_dock_to_odysseus("CUSTOM_BUTTON_DOCK_TO_ODYSSEUS")
 {
 }
 
@@ -424,4 +430,11 @@ void Keys::init()
     //Debug
     debug_show_fps.setLabel(tr("hotkey_menu", "Various"), tr("hotkey_debug", "Show FPS"));
     debug_show_timing.setLabel(tr("hotkey_menu", "Various"), tr("hotkey_debug", "Show debug timing"));
+
+    //Custom buttons
+    custom_button_launch_pad_1.setLabel(tr("hotkey_menu", "Custom"), tr("hotkey_custom", "Launch Landing Pad 1"));
+    custom_button_launch_pad_2.setLabel(tr("hotkey_menu", "Custom"), tr("hotkey_custom", "Launch Landing Pad 2"));
+    custom_button_launch_pad_3.setLabel(tr("hotkey_menu", "Custom"), tr("hotkey_custom", "Launch Landing Pad 3"));
+    custom_button_launch_pad_4.setLabel(tr("hotkey_menu", "Custom"), tr("hotkey_custom", "Launch Landing Pad 4"));
+    custom_button_dock_to_odysseus.setLabel(tr("hotkey_menu", "Custom"), tr("hotkey_custom", "Dock to Odysseus"));
 }

--- a/src/gui/hotkeyConfig.h
+++ b/src/gui/hotkeyConfig.h
@@ -188,6 +188,13 @@ public:
     //Debug
     sp::io::Keybinding debug_show_fps;
     sp::io::Keybinding debug_show_timing;
+    
+    //Custom buttons
+    sp::io::Keybinding custom_button_launch_pad_1;
+    sp::io::Keybinding custom_button_launch_pad_2;
+    sp::io::Keybinding custom_button_launch_pad_3;
+    sp::io::Keybinding custom_button_launch_pad_4;
+    sp::io::Keybinding custom_button_dock_to_odysseus;
 };
 extern Keys keys;
 

--- a/src/hardware/hardwareController.cpp
+++ b/src/hardware/hardwareController.cpp
@@ -384,6 +384,12 @@ bool HardwareController::getVariableValue(string variable_name, float& value)
     SHIP_VARIABLE("RedAlert", ship->getAlertLevel() == AL_RedAlert ? 1.0f : 0.0f);
     SHIP_VARIABLE("SelfDestruct", ship->activate_self_destruct ? 1.0f : 0.0f);
     SHIP_VARIABLE("SelfDestructCountdown", ship->self_destruct_countdown / 10.0f);
+    SHIP_VARIABLE("LandingPad1Status", ship->isLandingPadDestroyed(1) ? 0.0f : ship->isLandingPadDocked(1) ? 0.5f : 1.0f);
+    SHIP_VARIABLE("LandingPad2Status", ship->isLandingPadDestroyed(2) ? 0.0f : ship->isLandingPadDocked(2) ? 0.5f : 1.0f);
+    SHIP_VARIABLE("LandingPad3Status", ship->isLandingPadDestroyed(3) ? 0.0f : ship->isLandingPadDocked(3) ? 0.5f : 1.0f);
+    SHIP_VARIABLE("LandingPad4Status", ship->isLandingPadDestroyed(4) ? 0.0f : ship->isLandingPadDocked(4) ? 0.5f : 1.0f);
+    SHIP_VARIABLE("AbsImpulse", abs(ship->current_impulse * ship->getSystemEffectiveness(SYS_Impulse)));
+
     for(int n=0; n<max_weapon_tubes; n++)
     {
         SHIP_VARIABLE("TubeLoaded" + string(n), ship->weapon_tube[n].isLoaded() ? 1.0f : 0.0f);

--- a/src/screenComponents/customShipFunctions.cpp
+++ b/src/screenComponents/customShipFunctions.cpp
@@ -48,6 +48,22 @@ void GuiCustomShipFunctions::checkEntries()
                 label->setText(caption);
             }
         }
+
+        if (keys.custom_button_launch_pad_1.getDown() && entries[n].name == "launch_pad_1") {
+          my_spaceship->commandCustomFunction("launch_pad_1");          
+        }
+        if (keys.custom_button_launch_pad_2.getDown() && entries[n].name == "launch_pad_2") {
+          my_spaceship->commandCustomFunction("launch_pad_2");          
+        }
+        if (keys.custom_button_launch_pad_3.getDown() && entries[n].name == "launch_pad_3") {
+          my_spaceship->commandCustomFunction("launch_pad_3");          
+        }
+        if (keys.custom_button_launch_pad_4.getDown() && entries[n].name == "launch_pad_4") {
+          my_spaceship->commandCustomFunction("launch_pad_4");          
+        }
+        if (keys.custom_button_dock_to_odysseus.getDown() && entries[n].name == "dock_to_odysseus") {
+          my_spaceship->commandCustomFunction("dock_to_odysseus");          
+        }
     }
 }
 

--- a/src/screenComponents/shipDestroyedPopup.cpp
+++ b/src/screenComponents/shipDestroyedPopup.cpp
@@ -18,13 +18,16 @@ GuiShipDestroyedPopup::GuiShipDestroyedPopup(GuiCanvas* owner)
 
     ship_destroyed_overlay = new GuiOverlay(this, "SHIP_DESTROYED", glm::u8vec4(0, 0, 0, 128));
     (new GuiPanel(ship_destroyed_overlay, "SHIP_DESTROYED_FRAME"))->setPosition(0, 0, sp::Alignment::Center)->setSize(800, 100);
-    (new GuiLabel(ship_destroyed_overlay, "SHIP_DESTROYED_TEXT", "EMERGENCY RETRIEVAL ACTIVATED!", 70))->setPosition(0, 0, sp::Alignment::Center)->setSize(800, 100);
+    (new GuiLabel(ship_destroyed_overlay, "SHIP_DESTROYED_TEXT", "RETURNING TO ESS ODYSSEUS", 70))->setPosition(0, 0, sp::Alignment::Center)->setSize(800, 100);
 
-    ship_retrieved_overlay = new GuiOverlay(this, "SHIP_RETRIEVED", glm::u8vec4(0, 0, 0, 128));
-    (new GuiPanel(ship_retrieved_overlay, "SHIP_RETRIEVED_FRAME"))->setPosition(0, 0, sp::Alignment::Center)->setSize(800, 100);
-    (new GuiLabel(ship_retrieved_overlay, "SHIP_RETRIEVED_TEXT", "EMERGENCY DOCKING IN PROGRESS", 70))->setPosition(0, 0, sp::Alignment::Center)->setSize(800, 100);
+    ship_docking_overlay = new GuiOverlay(this, "SHIP_DOCKING", glm::u8vec4(0, 0, 0, 128));
+    (new GuiPanel(ship_docking_overlay, "SHIP_DOCKING_FRAME"))->setPosition(0, 0, sp::Alignment::Center)->setSize(500, 100);
+    (new GuiLabel(ship_docking_overlay, "SHIP_DOCKING_TEXT", "AUTOMATED DOCKING IN PROGRESS", 70))->setPosition(0, 0, sp::Alignment::Center)->setSize(800, 100);
 
-    ship_callsign = my_spaceship->getCallSign();
+    ship_docked_overlay = new GuiOverlay(this, "SHIP_DOCKED", glm::u8vec4(0, 0, 0, 128));
+    (new GuiPanel(ship_docked_overlay, "SHIP_DOCKED_FRAME"))->setPosition(0, 0, sp::Alignment::Center)->setSize(500, 100);
+    (new GuiLabel(ship_docked_overlay, "SHIP_DOCKED_TEXT", "DOCKING COMPLETE", 70))->setPosition(0, 0, sp::Alignment::Center)->setSize(500, 100);
+
     retrievable = my_spaceship->getCanBeDestroyed();
 
     show_timeout.start(5.0);
@@ -35,29 +38,37 @@ void GuiShipDestroyedPopup::onDraw(sp::RenderTarget& target)
     if (my_spaceship)
     {
         ship_destroyed_overlay->hide();
-        ship_retrieved_overlay->hide();
-        show_timeout.start(5.0);
+        ship_docking_overlay->hide();        
+        ship_docked_overlay->hide();
+        
+        show_timeout.start(0.5);
         
     } else {
-        if (show_timeout.isExpired()) {
-            soundManager->stopMusic();
-            if (!retrievable) {
+        if (!retrievable) {
+            returnToShipSelection(this->owner->getRenderLayer());
+            this->owner->destroy();    
+        }
+        else 
+        {
+            if (show_timeout.isExpired()) {
+                soundManager->stopMusic();
+                ship_destroyed_overlay->show();
+                docking_timeout.start(4.5);
+            }
+            if (docking_timeout.isExpired()) {
+                ship_destroyed_overlay->hide();
+                ship_docking_overlay->show();
+                docked_timeout.start(10.0);
+            }
+            if (docked_timeout.isExpired()) {
+                ship_docking_overlay->hide();
+                ship_docked_overlay->show();
+                return_timeout.start(5.0);
+            }
+            if (return_timeout.isExpired()) {
                 returnToShipSelection(this->owner->getRenderLayer());
                 this->owner->destroy();
-            } else {
-                ship_destroyed_overlay->show();
-                docked_timeout.start(25.0);
             }
         }
-        if (docked_timeout.isExpired()) {
-            ship_destroyed_overlay->hide();
-            ship_retrieved_overlay->show();
-            return_timeout.start(5.0);
-        }
-        if (return_timeout.isExpired()) {
-            returnToShipSelection(this->owner->getRenderLayer());
-            this->owner->destroy();
-        }
-
     }
 }

--- a/src/screenComponents/shipDestroyedPopup.cpp
+++ b/src/screenComponents/shipDestroyedPopup.cpp
@@ -3,6 +3,7 @@
 #include "spaceObjects/playerSpaceship.h"
 #include "soundManager.h"
 #include "main.h"
+#include "gameGlobalInfo.h"
 
 #include "gui/gui2_overlay.h"
 #include "gui/gui2_canvas.h"
@@ -16,13 +17,15 @@ GuiShipDestroyedPopup::GuiShipDestroyedPopup(GuiCanvas* owner)
     setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
     ship_destroyed_overlay = new GuiOverlay(this, "SHIP_DESTROYED", glm::u8vec4(0, 0, 0, 128));
-    (new GuiPanel(ship_destroyed_overlay, "SHIP_DESTROYED_FRAME"))->setPosition(0, 0, sp::Alignment::Center)->setSize(500, 100);
-    (new GuiLabel(ship_destroyed_overlay, "SHIP_DESTROYED_TEXT", "DOCKING ACTIVATED!", 70))->setPosition(0, 0, sp::Alignment::Center)->setSize(500, 100);
-    (new GuiButton(ship_destroyed_overlay, "SHIP_DESTROYED_BUTTON", tr("shipdestroyed", "Return"), [this]() {
-        soundManager->stopMusic();
-        returnToShipSelection(this->owner->getRenderLayer());
-        this->owner->destroy();
-    }))->setPosition(0, 75, sp::Alignment::Center)->setSize(500, 50);
+    (new GuiPanel(ship_destroyed_overlay, "SHIP_DESTROYED_FRAME"))->setPosition(0, 0, sp::Alignment::Center)->setSize(800, 100);
+    (new GuiLabel(ship_destroyed_overlay, "SHIP_DESTROYED_TEXT", "EMERGENCY RETRIEVAL ACTIVATED!", 70))->setPosition(0, 0, sp::Alignment::Center)->setSize(800, 100);
+
+    ship_retrieved_overlay = new GuiOverlay(this, "SHIP_RETRIEVED", glm::u8vec4(0, 0, 0, 128));
+    (new GuiPanel(ship_retrieved_overlay, "SHIP_RETRIEVED_FRAME"))->setPosition(0, 0, sp::Alignment::Center)->setSize(800, 100);
+    (new GuiLabel(ship_retrieved_overlay, "SHIP_RETRIEVED_TEXT", "EMERGENCY DOCKING IN PROGRESS", 70))->setPosition(0, 0, sp::Alignment::Center)->setSize(800, 100);
+
+    ship_callsign = my_spaceship->getCallSign();
+    retrievable = my_spaceship->getCanBeDestroyed();
 
     show_timeout.start(5.0);
 }
@@ -32,9 +35,29 @@ void GuiShipDestroyedPopup::onDraw(sp::RenderTarget& target)
     if (my_spaceship)
     {
         ship_destroyed_overlay->hide();
+        ship_retrieved_overlay->hide();
         show_timeout.start(5.0);
-    }else{
-        if (show_timeout.isExpired())
-            ship_destroyed_overlay->show();
+        
+    } else {
+        if (show_timeout.isExpired()) {
+            soundManager->stopMusic();
+            if (!retrievable) {
+                returnToShipSelection(this->owner->getRenderLayer());
+                this->owner->destroy();
+            } else {
+                ship_destroyed_overlay->show();
+                docked_timeout.start(25.0);
+            }
+        }
+        if (docked_timeout.isExpired()) {
+            ship_destroyed_overlay->hide();
+            ship_retrieved_overlay->show();
+            return_timeout.start(5.0);
+        }
+        if (return_timeout.isExpired()) {
+            returnToShipSelection(this->owner->getRenderLayer());
+            this->owner->destroy();
+        }
+
     }
 }

--- a/src/screenComponents/shipDestroyedPopup.cpp
+++ b/src/screenComponents/shipDestroyedPopup.cpp
@@ -21,7 +21,7 @@ GuiShipDestroyedPopup::GuiShipDestroyedPopup(GuiCanvas* owner)
     (new GuiLabel(ship_destroyed_overlay, "SHIP_DESTROYED_TEXT", "RETURNING TO ESS ODYSSEUS", 70))->setPosition(0, 0, sp::Alignment::Center)->setSize(800, 100);
 
     ship_docking_overlay = new GuiOverlay(this, "SHIP_DOCKING", glm::u8vec4(0, 0, 0, 128));
-    (new GuiPanel(ship_docking_overlay, "SHIP_DOCKING_FRAME"))->setPosition(0, 0, sp::Alignment::Center)->setSize(500, 100);
+    (new GuiPanel(ship_docking_overlay, "SHIP_DOCKING_FRAME"))->setPosition(0, 0, sp::Alignment::Center)->setSize(800, 100);
     (new GuiLabel(ship_docking_overlay, "SHIP_DOCKING_TEXT", "AUTOMATED DOCKING IN PROGRESS", 70))->setPosition(0, 0, sp::Alignment::Center)->setSize(800, 100);
 
     ship_docked_overlay = new GuiOverlay(this, "SHIP_DOCKED", glm::u8vec4(0, 0, 0, 128));

--- a/src/screenComponents/shipDestroyedPopup.h
+++ b/src/screenComponents/shipDestroyedPopup.h
@@ -13,8 +13,13 @@ class GuiShipDestroyedPopup : public GuiElement
 {
 private:
     GuiOverlay* ship_destroyed_overlay;
+    GuiOverlay* ship_retrieved_overlay;
     GuiCanvas* owner;
     sp::SystemTimer show_timeout;
+    sp::SystemTimer docked_timeout;
+    sp::SystemTimer return_timeout;
+    bool retrievable;
+    string ship_callsign; 
 
 public:
     GuiShipDestroyedPopup(GuiCanvas* owner);

--- a/src/screenComponents/shipDestroyedPopup.h
+++ b/src/screenComponents/shipDestroyedPopup.h
@@ -3,6 +3,7 @@
 
 #include "gui/gui2_element.h"
 #include "timer.h"
+#include "spaceObjects/playerSpaceship.h"
 
 
 class GuiPanel;
@@ -13,14 +14,14 @@ class GuiShipDestroyedPopup : public GuiElement
 {
 private:
     GuiOverlay* ship_destroyed_overlay;
-    GuiOverlay* ship_retrieved_overlay;
+    GuiOverlay* ship_docking_overlay;
+    GuiOverlay* ship_docked_overlay;
     GuiCanvas* owner;
     sp::SystemTimer show_timeout;
+    sp::SystemTimer docking_timeout;
     sp::SystemTimer docked_timeout;
     sp::SystemTimer return_timeout;
     bool retrievable;
-    string ship_callsign; 
-
 public:
     GuiShipDestroyedPopup(GuiCanvas* owner);
 

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -448,6 +448,27 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     /// All SpaceObjects within this radius are dealt damage upon self-destruction.
     /// Example: ship:getSelfDestructSize()
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getSelfDestructSize);
+    /// Sets the landing pad indicated by the parameter to state 'Launched', indicating that a ship is docked there.
+    /// Example: ship:setLandingPadDocked(1) -- sets the status of landing pad 1 to 'Docked''
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setLandingPadDocked);
+    /// Sets the landing pad indicated by the parameter to 'Destroyed', indicating that the ship associated with the landing pad has been destroyed/incapacitated.
+    /// Example: ship:setLandingPadDestroyed(1) -- sets the status of landing pad 1 to 'Destroyed'
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setLandingPadDestroyed);
+    /// Sets the landing pad indicated by the parameter to 'Launched', indicating that there is no ship docked there.
+    /// Example: ship:setLandingPadLaunched(1) -- sets the status of landing pad 1 to 'Launched''
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setLandingPadLaunched);
+    /// Checks whether the state of landing pad indicated by the parameter is 'Docked' or not.
+    /// Example: ship:isLandingPadDocked(3) -- returns 'true' if a ship is docked on landing pad 3; returns 'false' if the ship is destroyed or launched
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, isLandingPadDocked);
+    /// Checks whether the state of landing pad indicated by the parameter is 'Destroyed' or not.
+    /// Example: ship:isLandingPadDestroyed(3) -- returns 'true' if the ship associated with landing pad 3 is destroyed/incapacitated; returns 'false' if the ship is docked or launched
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, isLandingPadDestroyed);
+    /// Checks whether the state of landing pad indicated by the parameter is 'Launched' or not.
+    /// Example: ship:isLandingPadLaunched(3) -- returns 'true' if the ship associated with landing pad 3 is launched; returns 'false' if the ship is docked or destroyed
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, isLandingPadLaunched);
+    /// Returns the state of the landing pad in question as an enumerable with values 'LP_Docked', 'LP_Destroyed' and 'LP_Launched'.
+    /// Example: ship:getLandingPadState(3) -- returns 'LP_Docked' if a ship is docked on landing pad 3, 'LP_Destroyed if the ship associated with landing pad 3 has been destroyed (and has not yet been retrieved), and 'LP_Launched' if the ship associated with landing pad 3 has been launched
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getLandingPadState);
 }
 
 static const int16_t CMD_TARGET_ROTATION = 0x0001;

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -466,8 +466,11 @@ REGISTER_SCRIPT_SUBCLASS(PlayerSpaceship, SpaceShip)
     /// Checks whether the state of landing pad indicated by the parameter is 'Launched' or not.
     /// Example: ship:isLandingPadLaunched(3) -- returns 'true' if the ship associated with landing pad 3 is launched; returns 'false' if the ship is docked or destroyed
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, isLandingPadLaunched);
+    /// Sets the landing pad indicated by the number parameter to the state indicated by the state parameter (0 = 'Destroyed', 1 = 'Docked', 2 = 'Launched').
+    /// Example: ship:setLandingPadState(1, 1) -- sets the status of landing pad 1 to 'Docked'
+    REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, setLandingPadState);
     /// Returns the state of the landing pad in question as an enumerable with values 'LP_Docked', 'LP_Destroyed' and 'LP_Launched'.
-    /// Example: ship:getLandingPadState(3) -- returns 'LP_Docked' if a ship is docked on landing pad 3, 'LP_Destroyed if the ship associated with landing pad 3 has been destroyed (and has not yet been retrieved), and 'LP_Launched' if the ship associated with landing pad 3 has been launched
+    /// Example: ship:getLandingPadState(3) -- returns 'LP_Docked' if a ship is docked on landing pad 3, 'LP_Destroyed' if the ship associated with landing pad 3 has been destroyed (and has not yet been retrieved), and 'LP_Launched' if the ship associated with landing pad 3 has been launched
     REGISTER_SCRIPT_CLASS_FUNCTION(PlayerSpaceship, getLandingPadState);
 }
 

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -33,8 +33,8 @@ enum EAlertLevel
 
 enum ELandingPadState
 {
-    LP_Docked,     // Fighter/Starcaller is docked on the landing pad
     LP_Destroyed,  // Fighter/Starcaller has been destroyed by damage
+    LP_Docked,     // Fighter/Starcaller is docked on the landing pad
     LP_Launched    // Fighter/Starcaller has been launched and is in space
 };
 
@@ -167,7 +167,7 @@ public:
     ScriptSimpleCallback on_probe_unlink;
 
     // Odysseus-specific properties related to launching fighters
-    std::vector<ELandingPadState> landing_pad_state;
+    ELandingPadState landing_pad_state[5] = {LP_Destroyed, LP_Destroyed, LP_Destroyed, LP_Destroyed, LP_Destroyed};
 
     // Main screen content
     EMainScreenSetting main_screen_setting;
@@ -227,7 +227,7 @@ public:
     bool getCanLaunchProbe() { return can_launch_probe; }
 
     void setSelfDestructDamage(float amount) { self_destruct_damage = std::max(0.0f, amount); }
-    float getSelfDestructDamage() { return self_destruct_damage; }
+    float getSelfDestructDamage() { return self_destruct_damage; }  
     void setSelfDestructSize(float size) { self_destruct_size = std::max(0.0f, size); }
     float getSelfDestructSize() { return self_destruct_size; }
 
@@ -246,6 +246,7 @@ public:
     bool isLandingPadDocked(int number) { return landing_pad_state[number] == LP_Docked; }
     bool isLandingPadDestroyed(int number) { return landing_pad_state[number] == LP_Destroyed; }
     bool isLandingPadLaunched(int number) { return landing_pad_state[number] == LP_Launched; }
+    void setLandingPadState(int number, ELandingPadState state) { landing_pad_state[number] = state; }
     ELandingPadState getLandingPadState(int number) { return landing_pad_state[number]; }
 
     void addCustomButton(ECrewPosition position, string name, string caption, ScriptSimpleCallback callback, std::optional<int> order);

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -31,6 +31,13 @@ enum EAlertLevel
     AL_MAX          // ?
 };
 
+enum ELandingPadState
+{
+    LP_Docked,     // Fighter/Starcaller is docked on the landing pad
+    LP_Destroyed,  // Fighter/Starcaller has been destroyed by damage
+    LP_Launched    // Fighter/Starcaller has been launched and is in space
+};
+
 class PlayerSpaceship : public SpaceShip
 {
 public:
@@ -159,6 +166,9 @@ public:
     ScriptSimpleCallback on_probe_link;
     ScriptSimpleCallback on_probe_unlink;
 
+    // Odysseus-specific properties related to launching fighters
+    std::vector<ELandingPadState> landing_pad_state;
+
     // Main screen content
     EMainScreenSetting main_screen_setting;
     // Content overlaid on the main screen, such as comms
@@ -229,6 +239,14 @@ public:
     void onProbeLaunch(ScriptSimpleCallback callback);
     void onProbeLink(ScriptSimpleCallback callback);
     void onProbeUnlink(ScriptSimpleCallback callback);
+
+    void setLandingPadDocked(int number) { landing_pad_state[number] = LP_Docked; }
+    void setLandingPadDestroyed(int number) { landing_pad_state[number] = LP_Destroyed; }
+    void setLandingPadLaunched(int number) { landing_pad_state[number] = LP_Launched; }
+    bool isLandingPadDocked(int number) { return landing_pad_state[number] == LP_Docked; }
+    bool isLandingPadDestroyed(int number) { return landing_pad_state[number] == LP_Destroyed; }
+    bool isLandingPadLaunched(int number) { return landing_pad_state[number] == LP_Launched; }
+    ELandingPadState getLandingPadState(int number) { return landing_pad_state[number]; }
 
     void addCustomButton(ECrewPosition position, string name, string caption, ScriptSimpleCallback callback, std::optional<int> order);
     void addCustomInfo(ECrewPosition position, string name, string caption, std::optional<int> order);


### PR DESCRIPTION
Adds the following features:
* launch status tracking for fighters via DMX (as well as a few other new DMX outputs)
    * values: 0 = Destroyed, 127 = Docked, 255 = Launched
* launch status tracking via HTTP API
    * values: 0 = Destroyed, 1 = Docked, 2 = Launched
* hotkeys for launching fighters (and Starcaller) to Odysseus Relay station
    * work only if corresponding custom button is active
* hotkey for docking to Odysseus to fighters / Starcaller
    * works the same as clicking on the custom button
* moved the script commands for creating the custom buttons to the scenario files so that the created buttons work
* added a custom button "Sync buttons" to generate the fighter "allow" and "launch" buttons according to the landing pad statuses after they have been pushed to EE from backend after a jump
* changed the "Ship Destroyed" popup to have sequenced and more appropriate texts (need to be generic since could not figure out a way to successfully indicate whether ship has been destroyed by damage or through docking
    *  the docking (and emergency retrieval) procedure takes 20 sec, although the fighter is shown as "Docked" already at the beginning of it; the lighting sequences at the change from "Launched" to "Docked" and "Launched" to "Destroyed" should take this into account and have a 20 second sequence in the beginning for the docking sequence
    * also changed the procedure so that it does not require clicking a button but goes directly to ship selection (i.e. autoconnect) screen after 20 sec, ready to connect to the fighter again when it is spawned upon next launch
